### PR TITLE
fix/category-instantsearch-url-parameter

### DIFF
--- a/Adapter/Filter/Builder/Term.php
+++ b/Adapter/Filter/Builder/Term.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Algolia\AlgoliaSearchElastic\Adapter\Filter\Builder;
+
+use Algolia\AlgoliaSearch\Helper\AdapterHelper;
+use Magento\Catalog\Model\ProductFactory;
+use Magento\Elasticsearch\Model\Adapter\FieldMapperInterface;
+use Magento\Elasticsearch\SearchAdapter\Filter\Builder\Term as ElasticsearchTerm;
+use Magento\Framework\Search\Request\Filter\Term as TermFilterRequest;
+use Magento\Framework\Search\Request\FilterInterface as RequestFilterInterface;
+use function PHPSTORM_META\type;
+
+class Term extends ElasticsearchTerm
+{
+    /** @var AdapterHelper */
+    protected $adapterHelper;
+
+    /** @var ProductFactory */
+    protected $productFactory;
+
+    /**
+     * @param FieldMapperInterface $fieldMapper
+     */
+    public function __construct(
+        FieldMapperInterface $fieldMapper,
+        AdapterHelper $adapterHelper,
+        ProductFactory $productFactory
+    ) {
+        parent::__construct($fieldMapper);
+
+        $this->adapterHelper = $adapterHelper;
+        $this->productFactory = $productFactory;
+    }
+
+    /**
+     * @param RequestFilterInterface|TermFilterRequest $filter
+     * @return array
+     */
+    public function buildFilter(RequestFilterInterface $filter)
+    {
+        if (!$this->adapterHelper->isAllowed()
+            || !(
+                $this->adapterHelper->isSearch() ||
+                $this->adapterHelper->isReplaceCategory() ||
+                $this->adapterHelper->isReplaceAdvancedSearch() ||
+                $this->adapterHelper->isLandingPage()
+            )
+        ) {
+            return parent::buildFilter($filter);
+        }
+
+        $filterQuery = [];
+        if ($filter->getValue()) {
+            $operator = is_array($filter->getValue()) ? 'terms' : 'term';
+            $fieldName = $this->fieldMapper->getFieldName($filter->getField());
+            $fieldValue = $this->getFilterValue($fieldName, $filter->getValue());
+
+            $filterQuery []= [
+                $operator => [
+                    $fieldName => $fieldValue,
+                ],
+            ];
+        }
+        return $filterQuery;
+    }
+
+    private function getFilterValue($attribute, $value)
+    {
+        $facets = $this->adapterHelper->getFacets();
+        $facetAttributes = array_map(function($facet) {
+            return $facet['attribute'];
+        }, $facets);
+
+        if (in_array($attribute, $facetAttributes)) {
+            if (!is_array($value)) {
+                // only take the first value for now
+                $value = explode('~', $value)[0];
+                return $this->getOptionIdByLabel($attribute, $value);
+            }
+        }
+        return $value;
+    }
+
+    private function getOptionIdByLabel($attributeCode, $optionLabel)
+    {
+        $product = $this->productFactory->create();
+        $attribute = $product->getResource()->getAttribute($attributeCode);
+        $optionId = '';
+
+        if ($attribute && $attribute->usesSource()) {
+            $optionId = $attribute->getSource()->getOptionId($optionLabel);
+        }
+
+        return $optionId ? $optionId : $optionLabel;
+    }
+
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -4,4 +4,15 @@
     <preference for="Magento\Elasticsearch\SearchAdapter\Adapter" type="Algolia\AlgoliaSearchElastic\Adapter\AlgoliaElasticSearchAdapter"/>
     <preference for="Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Adapter" type="Algolia\AlgoliaSearchElastic\Adapter\AlgoliaElasticSearch5Adapter"/>
 
+    <preference for="Magento\Elasticsearch\SearchAdapter\Filter\Builder\Term" type="Algolia\AlgoliaSearchElastic\Adapter\Filter\Builder\Term"/>
+
+    <type name="Magento\Framework\Search\Dynamic\DataProviderFactory">
+        <arguments>
+            <argument name="dataProviders" xsi:type="array">
+                <item name="elasticsearch" xsi:type="string">Algolia\AlgoliaSearchElastic\Adapter\Algolia\Dynamic\DataProvider</item>
+                <item name="elasticsearch5" xsi:type="string">Algolia\AlgoliaSearchElastic\Adapter\Algolia\Dynamic\DataProvider</item>
+            </argument>
+        </arguments>
+    </type>
+
 </config>


### PR DESCRIPTION
Instantsearch enabled on category pages, when reloaded with a parameter set from instantsearch facets like ?color=Blue, elasticsearch will throw a bad request error as it cannot retrieve the query correctly. Need to translate the values over to their optionID to get this to work. 

What I did was create a Term builder that rewrites their Term builder to process the URL from instantsearch. This is a quick workaround. Ideally, I want to avoid altogether making a request to elasticsearch but this is due to the theme settings fetching from the DataProvider. 