### PR TITLE
Cleanup require in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,7 @@
   "license": ["MIT"],
   "version": "0.0.0",
   "require": {
-    "php": "~7.1.3||~7.2.0",
-    "algolia/algoliasearch-client-php": ">=1.27.0 <2.0",
-    "algolia/algoliasearch-magento-2": ">=1.8.0",
+    "algolia/algoliasearch-magento-2": ">=1.12.0",
     "magento/module-elasticsearch": ">=100.2.7"
   },
   "autoload": {


### PR DESCRIPTION
In PR I added 2 things:
1. PHP and  algolia/algoliasearch-client-php - these 2 require from algolia/algoliasearch-magento-2 and its` version provides right dependency.
2. Set minimal version algolia/algoliasearch-magento-2 to >=1.12.0. - related with module description and release notes of module.