### PR TITLE
Fix Bad Request Warning and Builder Aggregation

### DIFF
--- a/Adapter/Aggregation/Builder.php
+++ b/Adapter/Aggregation/Builder.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Algolia\AlgoliaSearchElastic\Adapter\Aggregation;
+
+use Algolia\AlgoliaSearch\Model\Indexer\Product;
+use Algolia\AlgoliaSearchElastic\Helper\ElasticAdapterHelper;
+use Magento\Catalog\Model\ProductFactory;
+use Magento\Elasticsearch\SearchAdapter\Aggregation\Builder as ElasticSearchBuilder;
+use Magento\Elasticsearch\SearchAdapter\Aggregation\Builder\BucketBuilderInterface;
+use Magento\Elasticsearch\SearchAdapter\Aggregation\DataProviderFactory;
+use Magento\Elasticsearch\SearchAdapter\QueryContainer;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Search\Dynamic\DataProviderInterface;
+use Magento\Framework\Search\RequestInterface;
+
+class Builder extends ElasticSearchBuilder
+{
+
+    /**
+     * @var DataProviderFactory
+     */
+    private $dataProviderFactory;
+
+    /**
+     * @var QueryContainer
+     */
+    private $query = null;
+
+    /**
+     * @var ProductFactory
+     */
+    private $productFactory;
+
+    /**
+     * @var \Magento\Catalog\Model\Product
+     */
+    private $product;
+
+    /**
+     * @var array
+     */
+    private $facets = [];
+
+    /**
+     * @param array $dataProviderContainer
+     * @param array $aggregationContainer
+     * @param DataProviderFactory|null $dataProviderFactory
+     * @param ProductFactory $productFactory
+     */
+    public function __construct(
+        array $dataProviderContainer,
+        array $aggregationContainer,
+        DataProviderFactory $dataProviderFactory = null,
+        ProductFactory $productFactory
+    ) {
+        $this->dataProviderContainer = array_map(
+            function (DataProviderInterface $dataProvider) {
+                return $dataProvider;
+            },
+            $dataProviderContainer
+        );
+        $this->aggregationContainer = array_map(
+            function (BucketBuilderInterface $bucketBuilder) {
+                return $bucketBuilder;
+            },
+            $aggregationContainer
+        );
+        $this->dataProviderFactory = $dataProviderFactory
+            ?: ObjectManager::getInstance()->get(DataProviderFactory::class);
+
+        $this->productFactory = $productFactory;
+    }
+
+    public function build(RequestInterface $request, array $queryResult)
+    {
+        $aggregations = [];
+        $buckets = $request->getAggregation();
+
+        $facets = $this->getFacets();
+
+        $dataProvider = $this->dataProviderFactory->create(
+            $this->dataProviderContainer[$request->getIndex()],
+            $this->query
+        );
+
+        foreach ($buckets as $bucket) {
+            if (count($facets) && isset($facets[$bucket->getField()])) {
+                $aggregations[$bucket->getName()] =
+                    $this->formatAggregation($bucket->getField(), $facets[$bucket->getField()]);
+            } else {
+                $bucketAggregationBuilder = $this->aggregationContainer[$bucket->getType()];
+                $aggregations[$bucket->getName()] = $bucketAggregationBuilder->build(
+                    $bucket,
+                    $request->getDimensions(),
+                    $queryResult,
+                    $dataProvider
+                );
+            }
+        }
+
+        $this->query = null;
+
+        return $aggregations;
+    }
+
+
+    private function formatAggregation($attribute, $facetData)
+    {
+        $aggregation = [];
+
+        foreach ($facetData as $value => $count) {
+            $optionId = $this->getOptionIdByLabel($attribute, $value);
+            $aggregation[$optionId] = [
+                'value' => (string) $optionId,
+                'count' => (string) $count,
+            ];
+        }
+
+        return $aggregation;
+    }
+
+    private function getOptionIdByLabel($attributeCode, $optionLabel)
+    {
+        $product = $this->productFactory->create();
+        $isAttributeExist = $product->getResource()->getAttribute($attributeCode);
+        $optionId = '';
+        if ($isAttributeExist && $isAttributeExist->usesSource()) {
+            $optionId = $isAttributeExist->getSource()->getOptionId($optionLabel);
+        }
+
+        return $optionId;
+    }
+
+    /**
+     * @return \Magento\Catalog\Model\Product
+     */
+    public function getProduct()
+    {
+        if (!$this->product) {
+            $this->product = $this->productFactory->create();
+        }
+
+        return $this->product;
+    }
+
+    /**
+     * Sets the QueryContainer instance to the internal property in order to use it in build process
+     *
+     * @param QueryContainer $query
+     * @return \Magento\Elasticsearch\SearchAdapter\Aggregation\Builder
+     */
+    public function setQuery(QueryContainer $query)
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    public function setFacets($facets)
+    {
+        $this->facets = $facets;
+    }
+
+    public function getFacets()
+    {
+        return $this->facets;
+    }
+
+}

--- a/Adapter/Aggregation/Builder.php
+++ b/Adapter/Aggregation/Builder.php
@@ -15,6 +15,15 @@ use Magento\Framework\Search\RequestInterface;
 
 class Builder extends ElasticSearchBuilder
 {
+    /**
+     * @var DataProviderInterface[]
+     */
+    protected $dataProviderContainer;
+
+    /**
+     * @var BucketBuilderInterface[]
+     */
+    protected $aggregationContainer;
 
     /**
      * @var DataProviderFactory
@@ -134,7 +143,7 @@ class Builder extends ElasticSearchBuilder
     /**
      * @return \Magento\Catalog\Model\Product
      */
-    public function getProduct()
+    private function getProduct()
     {
         if (!$this->product) {
             $this->product = $this->productFactory->create();
@@ -161,7 +170,7 @@ class Builder extends ElasticSearchBuilder
         $this->facets = $facets;
     }
 
-    public function getFacets()
+    private function getFacets()
     {
         return $this->facets;
     }

--- a/Adapter/Aggregation/Builder.php
+++ b/Adapter/Aggregation/Builder.php
@@ -16,16 +16,6 @@ use Magento\Framework\Search\RequestInterface;
 class Builder extends ElasticSearchBuilder
 {
     /**
-     * @var DataProviderInterface[]
-     */
-    protected $dataProviderContainer;
-
-    /**
-     * @var BucketBuilderInterface[]
-     */
-    protected $aggregationContainer;
-
-    /**
      * @var DataProviderFactory
      */
     private $dataProviderFactory;

--- a/Adapter/AlgoliaElasticSearch5Adapter.php
+++ b/Adapter/AlgoliaElasticSearch5Adapter.php
@@ -3,9 +3,10 @@
 namespace Algolia\AlgoliaSearchElastic\Adapter;
 
 use Algolia\AlgoliaSearch\Helper\AdapterHelper;
+use Algolia\AlgoliaSearchElastic\Helper\ElasticAdapterHelper;
 use Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Adapter as ElasticSearch5Adapter;
 use Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Mapper;
-use Magento\Elasticsearch\SearchAdapter\Aggregation\Builder as AggregationBuilder;
+use Algolia\AlgoliaSearchElastic\Adapter\Aggregation\Builder as AggregationBuilder;
 use Magento\Elasticsearch\SearchAdapter\ConnectionManager;
 use Magento\Elasticsearch\SearchAdapter\ResponseFactory;
 use Magento\Elasticsearch\SearchAdapter\QueryContainerFactory;
@@ -16,6 +17,9 @@ class AlgoliaElasticSearch5Adapter extends ElasticSearch5Adapter
 {
     /** @var AdapterHelper */
     private $adapterHelper;
+
+    /** @var ElasticAdapterHelper */
+    private $esAdapterHelper;
 
     /** @var QueryContainerFactory */
     private $queryContainerFactory;
@@ -29,6 +33,7 @@ class AlgoliaElasticSearch5Adapter extends ElasticSearch5Adapter
      * @param QueryContainerFactory $queryContainerFactory
      * @param LoggerInterface|null $logger
      * @param AdapterHelper $adapterHelper
+     * @param ElasticAdapterHelper $esAdapterHelper
      */
     public function __construct(
         ConnectionManager $connectionManager,
@@ -37,13 +42,15 @@ class AlgoliaElasticSearch5Adapter extends ElasticSearch5Adapter
         AggregationBuilder $aggregationBuilder,
         QueryContainerFactory $queryContainerFactory,
         LoggerInterface $logger = null,
-        AdapterHelper $adapterHelper
+        AdapterHelper $adapterHelper,
+        ElasticAdapterHelper $esAdapterHelper
     ) {
 
         parent::__construct($connectionManager, $mapper, $responseFactory, $aggregationBuilder, $queryContainerFactory,
             $logger);
         
         $this->adapterHelper = $adapterHelper;
+        $this->esAdapterHelper = $esAdapterHelper;
         $this->queryContainerFactory = $queryContainerFactory;
 
     }
@@ -54,15 +61,7 @@ class AlgoliaElasticSearch5Adapter extends ElasticSearch5Adapter
      */
     public function query(RequestInterface $request)
     {
-        if (!$this->adapterHelper->isAllowed()
-            || !$this->adapterHelper->isInstantEnabled()
-            || !(
-                $this->adapterHelper->isSearch() ||
-                $this->adapterHelper->isReplaceCategory() ||
-                $this->adapterHelper->isReplaceAdvancedSearch() ||
-                $this->adapterHelper->isLandingPage()
-            )
-        ) {
+        if (!$this->esAdapterHelper->replaceElasticSearchResults()) {
             return parent::query($request);
         }
 
@@ -78,7 +77,7 @@ class AlgoliaElasticSearch5Adapter extends ElasticSearch5Adapter
         try {
             // If instant search is on, do not make a search query unless SEO request is set to 'Yes'
             if (!$this->adapterHelper->isInstantEnabled() || $this->adapterHelper->makeSeoRequest()) {
-                list($rawResponse, $totalHits) = $this->adapterHelper->getDocumentsFromAlgolia();
+                list($rawResponse, $totalHits, $facets) = $this->adapterHelper->getDocumentsFromAlgolia();
                 $rawResponse = $this->transformResponseForElastic($rawResponse);
             }
 
@@ -86,6 +85,7 @@ class AlgoliaElasticSearch5Adapter extends ElasticSearch5Adapter
             return parent::query($request);
         }
 
+        $aggregationBuilder->setFacets($facets);
         $aggregations = $aggregationBuilder->build($request, $rawResponse);
 
         $response = [

--- a/Adapter/AlgoliaElasticSearchAdapter.php
+++ b/Adapter/AlgoliaElasticSearchAdapter.php
@@ -50,6 +50,7 @@ class AlgoliaElasticSearchAdapter extends ElasticSearchAdapter
     public function query(RequestInterface $request)
     {
         if (!$this->adapterHelper->isAllowed()
+            || !$this->adapterHelper->isInstantEnabled()
             || !(
                 $this->adapterHelper->isSearch() ||
                 $this->adapterHelper->isReplaceCategory() ||

--- a/Adapter/AlgoliaElasticSearchAdapter.php
+++ b/Adapter/AlgoliaElasticSearchAdapter.php
@@ -71,7 +71,7 @@ class AlgoliaElasticSearchAdapter extends ElasticSearchAdapter
         try {
             // If instant search is on, do not make a search query unless SEO request is set to 'Yes'
             if (!$this->adapterHelper->isInstantEnabled() || $this->adapterHelper->makeSeoRequest()) {
-                list($rawResponse, $totalHits, $facets) = $this->adapterHelper->getDocumentsFromAlgolia($request);
+                list($rawResponse, $totalHits, $facets) = $this->adapterHelper->getDocumentsFromAlgolia();
                 $rawResponse = $this->transformResponseForElastic($rawResponse);
             }
 
@@ -80,7 +80,8 @@ class AlgoliaElasticSearchAdapter extends ElasticSearchAdapter
         }
 
         $aggregationBuilder->setFacets($facets);
-        $aggregations = $aggregationBuilder->build($request, $rawResponse, $facets);
+        $aggregations = $aggregationBuilder->build($request, $rawResponse);
+
         $response = [
             'documents' => $rawResponse,
             'aggregations' => $aggregations,
@@ -100,8 +101,9 @@ class AlgoliaElasticSearchAdapter extends ElasticSearchAdapter
             foreach ($rawResponse as &$hit) {
                 $hit['_id'] = $hit['entity_id'];
             }
-            $rawResponse['hits'] = ['hits' => $rawResponse];
         }
+
+        $rawResponse['hits'] = ['hits' => $rawResponse];
 
         return $rawResponse;
     }

--- a/Helper/ElasticAdapterHelper.php
+++ b/Helper/ElasticAdapterHelper.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Algolia\AlgoliaSearchElastic\Helper;
+
+use Algolia\AlgoliaSearch\Helper\Adapter\FiltersHelper;
+use Algolia\AlgoliaSearch\Helper\AdapterHelper;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Data as AlgoliaDataHelper;
+use Magento\CatalogSearch\Helper\Data as CatalogSearchDataHelper;
+
+class ElasticAdapterHelper
+{
+    /**
+     * @var AdapterHelper
+     */
+    private $adapterHelper;
+
+    /**
+     * @var ConfigHelper
+     */
+    private $configHelper;
+
+    /**
+     * @param AdapterHelper $adapterHelper
+     * @param ConfigHelper $configHelper
+     */
+    public function __construct(
+        AdapterHelper $adapterHelper,
+        ConfigHelper $configHelper
+    ) {
+        $this->adapterHelper = $adapterHelper;
+        $this->configHelper = $configHelper;
+    }
+
+    /**
+     * @return bool
+     */
+    public function replaceElasticSearchResults()
+    {
+        if (!$this->adapterHelper->isAllowed()
+            || !(
+                $this->adapterHelper->isSearch() ||
+                $this->adapterHelper->isReplaceCategory() ||
+                $this->adapterHelper->isReplaceAdvancedSearch() ||
+                $this->adapterHelper->isLandingPage()
+            )
+        ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getStoreId()
+    {
+        return $this->configHelper->getStoreId();
+    }
+
+    public function getFacets()
+    {
+        return $this->configHelper->getFacets($this->getStoreId());
+    }
+
+}

--- a/Plugin/FulltextCollection.php
+++ b/Plugin/FulltextCollection.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Algolia\AlgoliaSearchElastic\Plugin;
+
+use Algolia\AlgoliaSearch\Helper\AdapterHelper;
+use Magento\Catalog\Model\ProductFactory;
+
+class FulltextCollection
+{
+    /** @var AdapterHelper */
+    private $adapterHelper;
+
+    /** @var ProductFactory */
+    private $productFactory;
+
+    /** @var \Magento\Catalog\Model\Product */
+    private $product;
+
+    private $facets;
+
+    /**
+     * @param AdapterHelper $adapterHelper
+     */
+    public function __construct(
+        AdapterHelper $adapterHelper,
+        ProductFactory $productFactory
+    ) {
+        $this->adapterHelper = $adapterHelper;
+        $this->productFactory = $productFactory;
+    }
+
+    public function replaceClient()
+    {
+        if (!$this->adapterHelper->isAllowed()
+            || !$this->adapterHelper->isInstantEnabled()
+            || !(
+                $this->adapterHelper->isSearch() ||
+                $this->adapterHelper->isReplaceCategory() ||
+                $this->adapterHelper->isReplaceAdvancedSearch() ||
+                $this->adapterHelper->isLandingPage()
+            )
+        ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param \Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection $subject
+     * @param $field
+     * @param null $condition
+     */
+    public function beforeAddFieldToFilter(
+        \Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection $subject,
+        $field,
+        $condition = null
+    ) {
+        if (!$condition || !$this->replaceClient()) {
+            return [$field, $condition];
+        }
+
+        if (in_array($field, $this->getFacets())) {
+            $condition = $this->getOptionIdByLabel($field, $condition);
+        }
+
+        return [$field, $condition];
+    }
+
+    /**
+     * @param string $attributeCode
+     * @param null $optionLabel
+     * @return string
+     */
+    private function getOptionIdByLabel($attributeCode, $optionLabel = null)
+    {
+        if ($optionLabel && !is_array($optionLabel)) {
+            $product = $this->getProduct();
+            $isAttributeExist = $product->getResource()->getAttribute($attributeCode);
+            if ($isAttributeExist && $isAttributeExist->usesSource()) {
+                $optionLabel = $isAttributeExist->getSource()->getOptionId($optionLabel);
+            }
+        }
+
+        return $optionLabel;
+    }
+
+    /**
+     * @return \Magento\Catalog\Model\Product
+     */
+    public function getProduct()
+    {
+        if (!$this->product) {
+            $this->product = $this->productFactory->create();
+        }
+
+        return $this->product;
+    }
+
+    public function getFacets()
+    {
+        if (!$this->facets) {
+            $facets = [];
+            $configFacets = $this->adapterHelper->getFacets();
+            if (is_array($configFacets) && count($configFacets)) {
+                $facets = array_map(function ($facet) {
+                    return $facet['attribute'];
+                }, $configFacets);
+            }
+
+            $this->facets = $facets;
+        }
+
+        return $this->facets;
+    }
+
+}

--- a/Plugin/FulltextCollection.php
+++ b/Plugin/FulltextCollection.php
@@ -45,9 +45,6 @@ class FulltextCollection
         $field,
         $condition = null
     ) {
-
-        // return [null, null];
-
         if (!$condition || !$this->esAdapterHelper->replaceElasticSearchResults()) {
             return [$field, $condition];
         }

--- a/Plugin/FulltextCollection.php
+++ b/Plugin/FulltextCollection.php
@@ -45,11 +45,14 @@ class FulltextCollection
         $field,
         $condition = null
     ) {
+
+        // return [null, null];
+
         if (!$condition || !$this->esAdapterHelper->replaceElasticSearchResults()) {
             return [$field, $condition];
         }
 
-        if (in_array($field, $this->getFacets())) {
+        if (is_array($this->getFacets()) && in_array($field, $this->getFacets())) {
             $condition = $this->getOptionIdByLabel($field, $condition);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
   "version": "0.0.0",
   "require": {
     "php": "~7.1.3||~7.2.0",
-    "algolia/algoliasearch-client-php": ">=1.27.0 <2.0",
     "algolia/algoliasearch-magento-2": ">=1.8.0",
     "magento/module-elasticsearch": ">=100.2.7"
   },

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -4,4 +4,8 @@
     <preference for="Magento\Elasticsearch\SearchAdapter\Adapter" type="Algolia\AlgoliaSearchElastic\Adapter\AlgoliaElasticSearchAdapter"/>
     <preference for="Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Adapter" type="Algolia\AlgoliaSearchElastic\Adapter\AlgoliaElasticSearch5Adapter"/>
 
+    <type name="Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection">
+        <plugin name="algoliasearchelastic_search_filter" type="Algolia\AlgoliaSearchElastic\Plugin\FulltextCollection" />
+    </type>
+
 </config>


### PR DESCRIPTION
**Issue**
Instantsearch enabled on category pages, when reloaded with a parameter set from instantsearch facets like ?color=Blue, elasticsearch will throw a bad request error as it cannot retrieve the query correctly. Need to translate the values over to their optionID to get this to work.

**Result**
Created a plugin for Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection::addFieldToFilter() method to change the option label value to the option ID. Also added a builder to pass facets from Algolia into the aggregator for the replaced buckets.